### PR TITLE
Fixes

### DIFF
--- a/ZDStickerView.podspec
+++ b/ZDStickerView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name			= 'ZDStickerView'
-  s.version			= '0.1.18'
+  s.version			= '0.2.0'
   s.summary 		= 'ZDStickerView is ObjC module for iOS and offers complete configurability, including movement, resizing, rotation and more, with one finger.'
   s.homepage 		= 'https://www.cocoacontrols.com/controls/zdstickerview'
   s.screenshots 	= 'https://github.com/zedoul/ZDStickerView/blob/develop/SCREENSHOT.png?raw=true'

--- a/ZDStickerView/ZDStickerView.m
+++ b/ZDStickerView/ZDStickerView.m
@@ -94,8 +94,26 @@
 
 
 - (void)pinchTranslate:(UIPinchGestureRecognizer *)recognizer {
-    recognizer.view.transform = CGAffineTransformScale(recognizer.view.transform, recognizer.scale, recognizer.scale);
-    recognizer.scale = 1;
+    static CGRect boundsBeforeScaling;
+    static CGAffineTransform transformBeforeScaling;
+    
+    if (recognizer.state == UIGestureRecognizerStateBegan) {
+        boundsBeforeScaling = recognizer.view.bounds;
+        transformBeforeScaling = recognizer.view.transform;
+    }
+    
+    CGPoint center = recognizer.view.center;
+    CGAffineTransform scale = CGAffineTransformScale(CGAffineTransformIdentity,
+                                                     recognizer.scale,
+                                                     recognizer.scale);
+    CGRect frame = CGRectApplyAffineTransform(boundsBeforeScaling, scale);
+    
+    frame.origin = CGPointMake(center.x - frame.size.width / 2,
+                               center.y - frame.size.height / 2);
+
+    recognizer.view.transform = CGAffineTransformIdentity;
+    recognizer.view.frame = frame;
+    recognizer.view.transform = transformBeforeScaling;
 }
 
 - (void)rotateTranslate:(UIRotationGestureRecognizer *)recognizer {

--- a/ZDStickerView/ZDStickerView.m
+++ b/ZDStickerView/ZDStickerView.m
@@ -25,6 +25,9 @@
 @property (strong, nonatomic) UIImageView *deleteControl;
 @property (strong, nonatomic) UIImageView *customControl;
 
+@property (strong, nonatomic) UIPinchGestureRecognizer *pinchRecognizer;
+@property (strong, nonatomic) UIRotationGestureRecognizer *rotationRecognizer;
+
 @property (nonatomic) BOOL preventsLayoutWhileResizing;
 
 @property (nonatomic) CGFloat deltaAngle;
@@ -232,8 +235,6 @@
     self.preventsDeleting = NO;
     self.preventsCustomButton = YES;
     self.translucencySticker = YES;
-    self.allowPinchToZoom = YES;
-    self.allowRotationGesture = YES;
     self.allowDragging = YES;
 
 #ifdef ZDSTICKERVIEW_LONGPRESS
@@ -273,23 +274,22 @@
     self.customControl.userInteractionEnabled = YES;
     self.customControl.image = nil;
     
-    if (self.allowPinchToZoom) {
-        UIPinchGestureRecognizer *pinchGesture = [[UIPinchGestureRecognizer alloc]
-                                                  initWithTarget:self
-                                                  action:@selector(pinchTranslate:)];
-        [self addGestureRecognizer:pinchGesture];
-    }
+    // Add pinch gesture recognizer.
+    self.pinchRecognizer = [[UIPinchGestureRecognizer alloc]
+                            initWithTarget:self
+                            action:@selector(pinchTranslate:)];
+    [self addGestureRecognizer:self.pinchRecognizer];
     
-    if (self.allowRotationGesture) {
-        UIRotationGestureRecognizer *rotationGesture = [[UIRotationGestureRecognizer alloc]
-                                                        initWithTarget:self
-                                                        action:@selector(rotateTranslate:)];
-        [self addGestureRecognizer:rotationGesture];
-    }
+    // Add rotation recognizer.
+    self.rotationRecognizer = [[UIRotationGestureRecognizer alloc]
+                               initWithTarget:self
+                               action:@selector(rotateTranslate:)];
+    [self addGestureRecognizer:self.rotationRecognizer];
     
+    // Add custom control recognizer.
     UITapGestureRecognizer *customTapGesture = [[UITapGestureRecognizer alloc]
                                                 initWithTarget:self
-                                                        action:@selector(customTap:)];
+                                                action:@selector(customTap:)];
     [self.customControl addGestureRecognizer:customTapGesture];
     [self addSubview:self.customControl];
 
@@ -494,7 +494,7 @@
     self.touchStart = touch;
 }
 
-
+#pragma mark - Property setter and getter
 
 - (void)hideDelHandle
 {
@@ -625,6 +625,22 @@
 
 - (void)setBorderWidth:(CGFloat)borderWidth {
     self.borderView.borderWidth = borderWidth;
+}
+
+- (BOOL)allowPinchToZoom {
+    return self.pinchRecognizer.isEnabled;
+}
+
+- (void)setAllowPinchToZoom:(BOOL)allowPinchToZoom {
+    self.pinchRecognizer.enabled = allowPinchToZoom;
+}
+
+- (BOOL)allowRotationGesture {
+    return self.rotationRecognizer.isEnabled;
+}
+
+-(void)setAllowRotationGesture:(BOOL)allowRotationGesture {
+    self.rotationRecognizer.enabled = allowRotationGesture;
 }
 
 

--- a/ZDStickerView/ZDStickerView.m
+++ b/ZDStickerView/ZDStickerView.m
@@ -107,6 +107,11 @@
         [self enableTransluceny:YES];
         self.prevPoint = [recognizer locationInView:self];
         [self setNeedsDisplay];
+        
+        // Inform delegate.
+        if ([self.stickerViewDelegate respondsToSelector:@selector(stickerViewDidBeginEditing:)]) {
+            [self.stickerViewDelegate stickerViewDidBeginEditing:self];
+        }
     }
     else if ([recognizer state] == UIGestureRecognizerStateChanged)
     {
@@ -185,6 +190,18 @@
         [self enableTransluceny:NO];
         self.prevPoint = [recognizer locationInView:self];
         [self setNeedsDisplay];
+        
+        // Inform delegate.
+        if ([self.stickerViewDelegate respondsToSelector:@selector(stickerViewDidEndEditing:)]) {
+            [self.stickerViewDelegate stickerViewDidEndEditing:self];
+        }
+    }
+    else if ([recognizer state] == UIGestureRecognizerStateCancelled)
+    {
+        // Inform delegate.
+        if ([self.stickerViewDelegate respondsToSelector:@selector(stickerViewDidCancelEditing:)]) {
+            [self.stickerViewDelegate stickerViewDidCancelEditing:self];
+        }
     }
 }
 

--- a/ZDStickerViewApp/ZDStickerViewApp/ViewController.m
+++ b/ZDStickerViewApp/ZDStickerViewApp/ViewController.m
@@ -56,6 +56,7 @@
     [userResizableView2 setButton:ZDStickerViewButtonCustom
                             image:[UIImage imageNamed:@"Write.png"]];
     userResizableView2.preventsResizing = YES;
+    userResizableView2.allowPinchToZoom = NO;
     [userResizableView2 showEditingHandles];
     [self.view addSubview:userResizableView2];
     
@@ -77,6 +78,7 @@
     [userResizableView setButton:ZDStickerViewButtonCustom
                            image:[UIImage imageNamed:@"Write.png"]];
     userResizableView.preventsResizing = NO;
+    userResizableView.allowRotationGesture = NO;
     [userResizableView showEditingHandles];
     [userResizableView2 addSubview:userResizableView];
 }


### PR DESCRIPTION
This Pull request fixes the following:

- `allowPinchToZoom` and `allowRotationGesture` had no effect when set after `init`
- the pinch-to-zoom gesture also scaled the edit handles
- the delegate methods were not called when using pinch or rotation

I also suggested a version update in the `.podspec` file. So if you (@zedoul) want, you can add a new tag and make the new version available via cocoapods.